### PR TITLE
Update all dependencies to their newest versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,11 +12,11 @@ categories   = ["embedded", "parsing"]
 
 [dependencies]
 csv         = "1.1.6"
-deku        = "0.14.1"
+deku        = "0.15.0"
 md5         = "0.7.0"
 parse_int   = "0.6.0"
-regex       = "1.6.0"
-serde       = { version = "1.0.145", features = ["derive"] }
-serde_plain = "1.0.0"
+regex       = "1.7.0"
+serde       = { version = "1.0.147", features = ["derive"] }
+serde_plain = "1.0.1"
 strum       = { version = "0.24.1",  features = ["derive"] }
-thiserror   = "1.0.35"
+thiserror   = "1.0.37"

--- a/src/partition.rs
+++ b/src/partition.rs
@@ -5,7 +5,7 @@ use std::{
     str::FromStr,
 };
 
-use deku::{DekuContainerRead, DekuEnumExt, DekuError, DekuRead};
+use deku::{DekuEnumExt, DekuError, DekuRead};
 use regex::Regex;
 use serde::{de::Error, Deserialize, Deserializer, Serialize};
 use strum::{EnumIter, EnumString, EnumVariantNames, FromRepr, IntoEnumIterator};


### PR DESCRIPTION
One of `deku`'s dependencies was yanked and is now causing issues for us downstream in other projects, and this should (hopefully) resolve that.