### PR TITLE
Make try_from() return the actual error with the partition table.

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -34,10 +34,6 @@ pub enum Error {
     )]
     InvalidOtadataPartitionSize,
 
-    /// The partition table is invalid
-    #[cfg_attr(feature = "std", error("The partition table is invalid"))]
-    InvalidPartitionTable,
-
     /// The length of the binary data is not a multiple of 32
     #[cfg_attr(
         feature = "std",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -100,13 +100,11 @@ impl PartitionTable {
 
         // If a partition table was detected from ESP-IDF (eg. using `esp-idf-sys`) then
         // it will be passed in its _binary_ form. Otherwise, it will be provided as a
-        // CSV.
-        if let Ok(part_table) = Self::try_from_bytes(&*input) {
-            Ok(part_table)
-        } else if let Ok(part_table) = Self::try_from_str(String::from_utf8(input)?) {
-            Ok(part_table)
+        // CSV. A binary partition table starts with 0xAA 0x50 magic bytes.
+        if input[..2] == [0xAA, 0x50] {
+            Self::try_from_bytes(&*input)
         } else {
-            Err(Error::InvalidPartitionTable)
+            Self::try_from_str(String::from_utf8(input)?)
         }
     }
 


### PR DESCRIPTION
The try_from() function used to just try both binary and csv partition tables, which resulted in a situation where it's unknown which of the two produced a sensible error. 

By checking for the magic bytes 0xAA 0x50 at the start we can know which type of file we are dealing with and parse that type, and return errors accordingly. It also makes Error::InvalidPartitionTable obsolete as it was only used in this specific scenario.

Errors from espflash now look like this:
```
Error:   × Failed to parse partition table
  ╰─▶ Partition with type 'data' and subtype 'ota' must have size of 0x2000 (8k) bytes
```

Should resolve #20