### PR TITLE
Replace md5 with md-5

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 csv         = { version = "1.3.0",   optional = true }
 deku        = { version = "0.17.0",  optional = true }
 heapless    = { version = "0.8.0",                            features = ["serde"]}
-md5         = { version = "0.7.0",   default-features = false }
+md-5        = { version = "0.10.6", default-features = false }
 parse_int   = { version = "0.6.0",   optional = true }
 regex       = { version = "1.10.3",   optional = true }
 serde       = { version = "1.0.196", default-features = false, features = ["derive"] }
@@ -27,4 +27,4 @@ thiserror   = { version = "1.0.57",  optional = true }
 
 [features]
 default = ["std"]
-std     = ["csv", "deku", "md5/std", "parse_int", "regex", "serde/std", "strum/std", "thiserror"]
+std     = ["csv", "deku", "parse_int", "regex", "serde/std", "strum/std", "thiserror"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -243,7 +243,7 @@ impl PartitionTable {
         let (writer, hash) = hasher.compute();
 
         writer.write_all(&MD5_PART_MAGIC_BYTES)?;
-        writer.write_all(&hash.as_slice())?;
+        writer.write_all(hash.as_slice())?;
 
         let written = self.partitions.len() * PARTITION_SIZE + 32;
         let padding = std::iter::repeat(0xFF)
@@ -372,7 +372,8 @@ impl PartitionTable {
 mod hash_writer {
     use md5::{
         digest::{consts::U16, generic_array::GenericArray},
-        Digest, Md5,
+        Digest,
+        Md5,
     };
 
     pub(crate) struct HashWriter<W> {


### PR DESCRIPTION
`espflash` already used `md-5`, so this ensures only a single md5 crate is used. `md-5`seemed a bit more popular.

Noticed this because of this `cargo doc`warning:

```
warning: output filename collision.
The lib target `md5` in package `md5 v0.7.0` has the same output filename as the lib target `md5` in package `md-5 v0.10.6`.
Colliding filename is: /Users/tiwalun/code/probe-rs/target/doc/md5/index.html
The targets should have unique names.
This is a known bug where multiple crates with the same name use
the same path; see <https://github.com/rust-lang/cargo/issues/6313>.
```